### PR TITLE
WIP: Changes to allow payment and database to run on OCP 3 and 4

### DIFF
--- a/database/Containerfile
+++ b/database/Containerfile
@@ -4,5 +4,12 @@ ENV POSTGRES_USER=patient_portal
 ENV POSTGRES_PASSWORD=secret
 ENV POSTGRES_HOST_AUTH_METHOD=scram-sha-256
 ENV POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
+ENV PGDATA=/pgdata/data
 
 COPY data.sql /docker-entrypoint-initdb.d/data.sql
+
+# This is required for OpenShift, as the base postgres
+# image runs as root
+RUN mkdir /pgdata && \
+    chgrp -R 0 /docker-entrypoint-initdb.d/data.sql /pgdata && \
+    chmod -R g+rwX /docker-entrypoint-initdb.d/data.sql /pgdata

--- a/payment-processor/Containerfile
+++ b/payment-processor/Containerfile
@@ -4,4 +4,4 @@ RUN microdnf -y install java-11-openjdk-headless && microdnf clean all
 
 ADD target/ /app/target
 
-ENTRYPOINT ["java", "-jar", "/app/target/quarkus-app/quarkus-run.jar"]
+ENTRYPOINT ["java", "-Dcom.redhat.fips=false", "-jar", "/app/target/quarkus-app/quarkus-run.jar"]


### PR DESCRIPTION
There are two changes on this PR, and one more is required for using Patient Portal on OCP 3:

- OCP 4 runs with FIPS mode enabled, and it was failing with the error `org.apache.camel.RuntimeCamelException: Error invoking generate with {}: invalid null LoadStoreParameter` (see #2); this changes disables FIPS on the Java invocation
- All OCP runs containers as non-root.  The postgres base image used by the database container poses some difficulties in adapting it for OCP, as the process itself is supposed to start as root, make some permission changes, and then move to the 'postgres' user in the container.  The proposed fix sets a different `PGDATA` directory, to be created by Postgres, but whose parent's group is 0 (root) and has group write permission.  That setup allows the user selected by OCP to run the container to create the actual `PGDATA` and proceed with the execution.

The final change that needs to be done is to re-build all those images with `--format=docker`, so they can work with OCP 3, as the OCI format does not work on that version